### PR TITLE
Add simplified Chinese translation

### DIFF
--- a/assets/flag_zhHans.svg
+++ b/assets/flag_zhHans.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  width="75" height="55" viewBox="0 0 30 20">
+    <defs>
+        <path id="s" d="M0,-1 0.587785,0.809017 -0.951057,-0.309017H0.951057L-0.587785,0.809017z" fill="#FFFF00"/>
+    </defs>
+    <rect width="75" height="55" fill="#EE1C25"/>
+    <use xlink:href="#s" transform="translate(5,5) scale(3)"/>
+    <use xlink:href="#s" transform="translate(10,2) rotate(23.036243)"/>
+    <use xlink:href="#s" transform="translate(12,4) rotate(45.869898)"/>
+    <use xlink:href="#s" transform="translate(12,7) rotate(69.945396)"/>
+    <use xlink:href="#s" transform="translate(10,9) rotate(20.659808)"/>
+</svg>

--- a/lib/locales/zh_hans.dart
+++ b/lib/locales/zh_hans.dart
@@ -1,0 +1,55 @@
+Map<String, String> get getZhHans => {
+      'CONNECT': "连接",
+      'Connect devices to the same network - use Wi-Fi or Mobile Hotspot':
+          "将设备连接至相同网络下——使用Wi-Fi或手机热点",
+      'SEND': '发送',
+      'Select any file you like': '选择任何你喜欢的文件',
+      'RECEIVE': '接收',
+      'Open given link on another device in any browser':
+          '在另一台设备的任何浏览器中打开给出的超链接',
+      'DONE': '完成',
+      'NEXT': '下一步',
+      'loading...': '加载中...',
+      'Mobile Hotspot': '手机热点',
+      'Connect to': "连接到",
+      'or set up a': '或者设置一个',
+      ' Mobile Hotspot': ' 手机热点',
+      'Not connected': "未连接",
+      'Now open this link': '在任何浏览器中',
+      'in any browser': '打开这个超链接',
+      'The recipient needs to be connected': "接收者需要连接",
+      'to the same network': '至相同网络下',
+      'Select file': '选择文件',
+      'Latest': '历史记录',
+      'Undefined': '未定义',
+      'EVERYWHERE': 'EVERYWHERE',
+      'Sharik is available for Android, Windows, MacOS and Linux!':
+          'Sharik支持 Android, Windows, MacOS 和 Linux 平台!',
+      'Click here to learn more': '点击了解更多',
+      'Copied to Clipboard': '已复制到剪贴板',
+      'Type some text': '输入一些文本',
+      'Close': '关闭',
+      'Send': '发送',
+      'Text': '文本',
+      'App': '应用',
+      'Hide system apps': '隐藏系统应用',
+      'Hide non-launchable apps': '隐藏没有启动器的应用',
+      'Search': '搜索',
+      //v2.1
+      'Updates': '检查更新',
+      'The latest version is already installed':
+          '已安装最新版本',
+      'Current version': '当前版本号',
+      'The latest version': '最新版本号',
+      'Changelog': '修改日志',
+
+      //v2.2
+      'Receiver': '接收',
+
+      //v2.4 (fonts)
+      'Andika': 'Andika',
+      'Comfortaa': 'Comfortaa',
+
+      //v2.5 (ios)
+      'Gallery': 'Gallery'
+    };

--- a/lib/models/locale.dart
+++ b/lib/models/locale.dart
@@ -7,6 +7,7 @@ import '../locales/in_hi.dart';
 import '../locales/pl.dart';
 import '../locales/ru.dart';
 import '../locales/ua.dart';
+import '../locales/zh_hans.dart';
 
 part 'locale.g.dart';
 
@@ -27,6 +28,8 @@ enum LocaleModel {
   inHi,
   @HiveField(6)
   inGu,
+  @HiveField(7)
+  zhHans,
 }
 
 String locale2sign(LocaleModel locale) => locale.toString().split('.').last;
@@ -53,6 +56,9 @@ String locale2name(LocaleModel locale) {
       break;
     case LocaleModel.inGu:
       return 'ગુજરાતી';
+      break;
+    case LocaleModel.zhHans:
+      return '简体中文';
       break;
   }
   throw Exception('Unknown locale');
@@ -87,6 +93,9 @@ LocaleAdapter getLocaleAdapter(LocaleModel locale) {
       break;
     case LocaleModel.inGu:
       return LocaleAdapter(map: getInGu, locale: locale);
+      break;
+    case LocaleModel.zhHans:
+      return LocaleAdapter(map: getZhHans, locale: locale);
       break;
   }
   throw Exception('no such local!!!');

--- a/lib/models/locale.g.dart
+++ b/lib/models/locale.g.dart
@@ -27,6 +27,8 @@ class LocaleModelAdapter extends TypeAdapter<LocaleModel> {
         return LocaleModel.inHi;
       case 6:
         return LocaleModel.inGu;
+      case 7:
+        return LocaleModel.zhHans;
       default:
         return null;
     }
@@ -55,6 +57,9 @@ class LocaleModelAdapter extends TypeAdapter<LocaleModel> {
         break;
       case LocaleModel.inGu:
         writer.writeByte(6);
+        break;
+      case LocaleModel.zhHans:
+        writer.writeByte(7);
         break;
     }
   }

--- a/lib/pages/language.dart
+++ b/lib/pages/language.dart
@@ -42,6 +42,8 @@ class LanguagePage extends StatelessWidget {
           const SizedBox(height: 14),
           LanguageButton(LocaleModel.ua, model),
           const SizedBox(height: 14),
+          LanguageButton(LocaleModel.zhHans, model),
+          const SizedBox(height: 14),
         ],
       ),
     );

--- a/media/store.yaml
+++ b/media/store.yaml
@@ -629,7 +629,7 @@ zh_Hans:
   Short description: "一个开源跨平台的本地网络文件分享解决方案"
   # 4000 characters
   Full description: |
-    Sharik十一个开源跨平台的通过Wi-Fi或手机热点分享文件的解决方案。
+    Sharik是一个开源跨平台的通过Wi-Fi或手机热点分享文件的解决方案。
 
     这个应用帮助你方便地发送照片、应用、文件、文本等几乎任何东西到所有连接到相同网络的设备上，方便快捷。
 

--- a/media/store.yaml
+++ b/media/store.yaml
@@ -38,6 +38,7 @@ en:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK IS ALSO AVAILABLE FOR:
       - Windows
@@ -90,6 +91,7 @@ fa:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     همچنین شریک برای این پلتفرم ها موجود می باشد:
       - Windows
@@ -143,6 +145,7 @@ ar:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     شارك متوفر أيضا لـ:
       - نظام الويندوز
@@ -191,6 +194,7 @@ ru:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK ТАКЖЕ ДОСТУПЕН ДЛЯ:
       - Windows (Виндовс)
@@ -239,6 +243,7 @@ uk:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK ТАКОЖ ДОСТУПНИЙ ДЛЯ:
       - Windows (Віндовс)
@@ -288,6 +293,7 @@ pl:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK JEST RÓWNIEŻ DOSTĘPNY DLA:
       - Windows
@@ -334,6 +340,7 @@ in-gu:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     Sharik પણ આ માટે ઉપલબ્ધ છે:
       - Windows
@@ -382,6 +389,7 @@ in-hi:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK के लिए भी उपलब्ध है:
       - Windows
@@ -436,6 +444,7 @@ in-hi:
       - Portuguese (Português do Brasil)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK TAMBÉM ESTÁ DISPONÍVEL PARA:
       - Windows
@@ -489,6 +498,7 @@ sk:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK JE K DISPOZÍCII PRE:
       - Windows
@@ -542,6 +552,7 @@ tr:
       - Ukrainian (Українська)
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
 
     SHARIK ŞU PLATFORMLARDA MEVCUT:
       - Windows
@@ -595,6 +606,7 @@ ml:
       - Slovak (Slovenčina)
       - Turkish (Türkçe)
       - Malayalam (മലയാളം)
+      - Chinese Simplified (简体中文)
 
     ഷെയറിക് താഴെപ്പറയുന്ന പ്ലാറ്റ്‌ഫോമുകളിൽ ലഭ്യമാണ്:
       - വിൻഡോസ്
@@ -607,3 +619,55 @@ ml:
 
 
     ഇപ്പോൾ തന്നെ ഷെയറിക് ഡൗൺലോഡ് ചെയ്യുക!
+
+zh_Hans:
+  # 50 characters
+  Name: "Sharik - 通过 WI-FI 分享文件"
+  # 60 characters
+  Very short description: "Sharik 使你方便地通过本地网络分享文件"
+  # 80 characters
+  Short description: "一个开源跨平台的本地网络文件分享解决方案"
+  # 4000 characters
+  Full description: |
+    Sharik十一个开源跨平台的通过Wi-Fi或手机热点分享文件的解决方案。
+
+    这个应用帮助你方便地发送照片、应用、文件、文本等几乎任何东西到所有连接到相同网络的设备上，方便快捷。
+
+    通过引导页面选择一种语言后，你可以在主屏幕看到分享按钮和最近分享的文件。在这个项目中，你可以分享图像、文件、安装过的应用或者一些简单的文本内容。选择文件后，你将进入文件分享页面，在这里你可以查看你的连接状态（Wi-Fi或手机热点）和你需要在其他设备输入的URL。在其他设备的浏览器输入这个URL并回车后，你分享的文件将开始下载。请保证所有设备已被连接至相同网络。
+
+    考虑到你可能在多台设备安装了Sharik，此时在一台设备分享文件后，你只需要简单点击另一台设备的Sharik底部面板上的“接收”按钮。点击后将展示接收界面，如果Sharik发现你的本地网络中的另一台设备正在分享东西，它将会被展示在这里。你可以点击它，然后浏览器会被打开，自动开始下载。
+
+    Sharik使用上完全免费，并且没有广告。另外，Sharik的源代码发布在Github，所以任何人都可以参与开发。如果你喜欢Sharik，请到Github仓库点一个star，并考虑参与贡献：添加一门新的语言翻译或者贡献代码。
+
+    Sharik使用Dart、Flutter、Hover.build和Golang开发并基于MIT开源协议发布。
+
+    你可以发送：
+      1. 图像 (jpg, png, gif, etc)
+      2. 应用 (apk)
+      3. 文件 (zip, rar, 7z, pdf, etc)
+      4. 文本
+
+    SHARIK在这些语言下可用:
+      - English (English)
+      - Persian (فارسی)
+      - Arabic (عربي)
+      - Hindi (हिन्दी)
+      - Russian (Русский)
+      - Gujarati (ગુજરાતી)
+      - Polski (Polski)
+      - Ukrainian (Українська)
+      - Slovak (Slovenčina)
+      - Turkish (Türkçe)
+      - Chinese Simplified (简体中文)
+
+    SHARIK支持下列平台:
+      - Windows
+      - macOS
+      - Linux
+      - Android
+      - iOS
+
+    GitHub page: https://github.com/marchellodev/sharik
+
+
+    立即下载Sharik！


### PR DESCRIPTION
# Added Chinese translation

The flag image is from [Wikipedia](https://zh.wikipedia.org/wiki/File:Flag_of_the_People%27s_Republic_of_China.svg)

## Issue:

The flag image is not displayed properly. I am not a Flutter developer and cannot solve this problem.

---

# 添加了中文翻译

旗帜图案来自[Wikipedia](https://zh.wikipedia.org/wiki/File:Flag_of_the_People%27s_Republic_of_China.svg)

## 问题：

旗帜图案显示不正常。我不是一个Flutter开发者，不能解决这个问题。